### PR TITLE
Change TextField alias to StringField due to WTForms deprecation

### DIFF
--- a/apps/authentication/forms.py
+++ b/apps/authentication/forms.py
@@ -4,14 +4,14 @@ Copyright (c) 2019 - present AppSeed.us
 """
 
 from flask_wtf import FlaskForm
-from wtforms import TextField, PasswordField, HiddenField
+from wtforms import StringField, PasswordField, HiddenField
 from wtforms.validators import Email, DataRequired, EqualTo
 
 # login and registration
 
 
 class LoginForm(FlaskForm):
-    username = TextField('Username',
+    username = StringField('Username',
                          id='username_login',
                          validators=[DataRequired()])
     password = PasswordField('Password',
@@ -20,10 +20,10 @@ class LoginForm(FlaskForm):
 
 
 class CreateAccountForm(FlaskForm):
-    username = TextField('Username',
+    username = StringField('Username',
                          id='username_create',
                          validators=[DataRequired()])
-    email = TextField('Email',
+    email = StringField('Email',
                       id='email_create',
                       validators=[DataRequired(), Email()])
     password = PasswordField('Password',
@@ -32,7 +32,7 @@ class CreateAccountForm(FlaskForm):
 
 
 class ForgotPasswordForm(FlaskForm):
-    email = TextField('Email',
+    email = StringField('Email',
                       id='email_create',
                       validators=[DataRequired(), Email()])
 

--- a/apps/datatables/forms.py
+++ b/apps/datatables/forms.py
@@ -4,11 +4,11 @@ Copyright (c) 2019 - present AppSeed.us
 """
 
 from flask_wtf import FlaskForm
-from wtforms import TextField, SelectField, FileField
+from wtforms import StringField, SelectField, FileField
 from wtforms.validators import Email, DataRequired
 
 
 class DatatableForm(FlaskForm):
     type   = SelectField('Type', id='type', choices=[("product", "Product"), ("transaction", "Transaction")], render_kw={'class':'form-select type'})
-    name   = TextField('Name', id='name', validators=[DataRequired()], render_kw={'class':'form-control name'})
-    value  = TextField('Value', id='value', validators=[DataRequired()], render_kw={'class':'form-control value'})
+    name   = StringField('Name', id='name', validators=[DataRequired()], render_kw={'class':'form-control name'})
+    value  = StringField('Value', id='value', validators=[DataRequired()], render_kw={'class':'form-control value'})

--- a/apps/profile/forms.py
+++ b/apps/profile/forms.py
@@ -4,22 +4,22 @@ Copyright (c) 2019 - present AppSeed.us
 """
 
 from flask_wtf import FlaskForm
-from wtforms import TextField, SelectField, FileField
+from wtforms import StringField, SelectField, FileField
 from wtforms.validators import Email, DataRequired
 
-# user profile 
+# user profile
 
 class ProfileForm(FlaskForm):
-    firstname  = TextField('First Name', id='first_name', validators=[DataRequired()])
-    lastname   = TextField('Last Name', id='last_name', validators=[DataRequired()])
-    birthday   = TextField('Birthday', id='birthday', validators=[DataRequired()])
+    firstname  = StringField('First Name', id='first_name', validators=[DataRequired()])
+    lastname   = StringField('Last Name', id='last_name', validators=[DataRequired()])
+    birthday   = StringField('Birthday', id='birthday', validators=[DataRequired()])
     gender     = SelectField('Gender', id='gender', choices=[("1", "Male"), ("2", "Female")])
-    email      = TextField('Email', id='email', validators=[DataRequired(), Email()])
-    phone      = TextField('Phone', id='phone', validators=[DataRequired()])
-    address    = TextField('Address', id='address', validators=[DataRequired()])
-    number     = TextField('Number', id='number', validators=[DataRequired()])
-    city       = TextField('City', id='city', validators=[DataRequired()])
-    state      = TextField('State', id='state', validators=[DataRequired()])
-    country    = TextField('Country', id='country', validators=[DataRequired()])
-    zipcode    = TextField('Zip Code', id='zipcode', validators=[DataRequired()])
+    email      = StringField('Email', id='email', validators=[DataRequired(), Email()])
+    phone      = StringField('Phone', id='phone', validators=[DataRequired()])
+    address    = StringField('Address', id='address', validators=[DataRequired()])
+    number     = StringField('Number', id='number', validators=[DataRequired()])
+    city       = StringField('City', id='city', validators=[DataRequired()])
+    state      = StringField('State', id='state', validators=[DataRequired()])
+    country    = StringField('Country', id='country', validators=[DataRequired()])
+    zipcode    = StringField('Zip Code', id='zipcode', validators=[DataRequired()])
     photo      = FileField('Profile Photo', id='photo', validators=[DataRequired()])


### PR DESCRIPTION

I'm getting this error out of the box on a fresh clone, virtualenv, pip install, and `flask run`: 
```
ImportError: cannot import name 'TextField' from 'wtforms' (boilerplate-code-flask-dashboard/env/lib/python3.9/site-packages/wtforms/__init__.py)
```
It looks like `TextField` is deprecated since 2.3.x and flask-wtf doesn't pin the WTForms version.
https://wtforms.readthedocs.io/en/2.3.x/whats_new/?highlight=textfield
https://github.com/wtforms/flask-wtf/blob/main/setup.py#L5

This change replaces all occurrences of `TextField` with `StringField`. 

Signed-off-by: Kevin <kevin@stealsyour.pw>